### PR TITLE
Fix path in install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Instructions
 
 2. Add the following settings::
 
-    TEST_RUNNER = 'django_slowtests.DiscoverSlowestTestsRunner'
+    TEST_RUNNER = 'django_slowtests.testrunner.DiscoverSlowestTestsRunner'
     NUM_SLOW_TESTS = 10
 
 3. Run test suite::


### PR DESCRIPTION
I tested with Django 1.9.3 and Python 3.5.1 and worked that way, so I guess it might be a typo in the `README`.