### PR TITLE
Allow the user to filter slow tests above a threshold

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,9 @@ Instructions
     TEST_RUNNER = 'django_slowtests.testrunner.DiscoverSlowestTestsRunner'
     NUM_SLOW_TESTS = 10
 
+    # (Optional)
+    SLOW_TEST_THRESHOLD_MS = 200  # Only show tests slower than 200ms
+
 3. Run test suite::
 
     $ python manage.py test

--- a/django_slowtests/testrunner.py
+++ b/django_slowtests/testrunner.py
@@ -9,6 +9,7 @@ from django.conf import settings
 
 TIMINGS = {}
 NUM_SLOW_TESTS = getattr(settings, 'NUM_SLOW_TESTS', 10)
+SLOW_TEST_THRESHOLD_MS = getattr(settings, 'SLOW_TEST_THRESHOLD_MS', 0)
 
 
 class TimingSuite(TestSuite):
@@ -65,11 +66,43 @@ class DiscoverSlowestTestsRunner(DiscoverRunner):
 
     def teardown_test_environment(self, **kwargs):
         super(DiscoverSlowestTestsRunner, self).teardown_test_environment(**kwargs)
+
+        # Grab slowest tests
         by_time = sorted(
             iter(TIMINGS.items()),
             key=operator.itemgetter(1),
             reverse=True
         )[:NUM_SLOW_TESTS]
-        print("\n%s slowest tests:" % NUM_SLOW_TESTS)
-        for func_name, timing in by_time:
+
+        test_results = by_time
+
+        if SLOW_TEST_THRESHOLD_MS:
+            # Filter tests by threshold
+            test_results = []
+
+            for result in by_time:
+                # Convert test time from seconds to miliseconds for comparison
+                result_time_ms = result[1] * 1000
+
+                # If the test was under the threshold
+                # don't show it to the user
+                if result_time_ms < SLOW_TEST_THRESHOLD_MS:
+                    continue
+
+                test_results.append(result)
+
+        test_result_count = len(test_results)
+
+        if test_result_count:
+            if SLOW_TEST_THRESHOLD_MS:
+                print("\n{r} slowest tests over {ms}ms:".format(
+                    r=test_result_count, ms=SLOW_TEST_THRESHOLD_MS)
+                )
+            else:
+                print("\n{r} slowest tests:".format(r=test_result_count))
+
+        for func_name, timing in test_results:
             print(("{t:.4f}s {f}".format(f=func_name, t=timing)))
+
+        if not len(test_results) and SLOW_TEST_THRESHOLD_MS:
+            print("\nNo tests slower than {ms}ms".format(ms=SLOW_TEST_THRESHOLD_MS))


### PR DESCRIPTION
I have added an option to allow a user to specify a threshold so only tests slower than `SLOW_TEST_THRESHOLD_MS` will be shown.

Without specifying the setting the slowest tests will always show as expected.

```
$ python manage.py test
Creating test database for alias 'default'...
..........
----------------------------------------------------------------------
Ran 10 tests in 0.413s

OK
Destroying test database for alias 'default'...

10 slowest tests:
0.3597s test_detail_view_with_a_future_poll (polls.tests.PollIndexDetailTests)
0.2843s test_detail_view_with_a_past_poll (polls.tests.PollIndexDetailTests)
0.0068s test_index_view_with_a_future_poll (polls.tests.PollViewTests)
0.0047s test_index_view_with_a_past_poll (polls.tests.PollViewTests)
0.0045s test_index_view_with_two_past_polls (polls.tests.PollViewTests)
0.0041s test_index_view_with_future_poll_and_past_poll (polls.tests.PollViewTests)
0.0036s test_index_view_with_no_polls (polls.tests.PollViewTests)
0.0003s test_was_published_recently_with_future_poll (polls.tests.PollMethodTests)
0.0002s test_was_published_recently_with_recent_poll (polls.tests.PollMethodTests)
0.0002s test_was_published_recently_with_old_poll (polls.tests.PollMethodTests)
```

But if you have the option to specify for example `SLOW_TEST_THRESHOLD_MS = 200` then only tests slower than this limit will show:

```
$ python manage.py test
Creating test database for alias 'default'...
..........
----------------------------------------------------------------------
Ran 10 tests in 0.413s

OK
Destroying test database for alias 'default'...

2 slowest tests over 200ms:
0.3597s test_detail_view_with_a_future_poll (polls.tests.PollIndexDetailTests)
0.2843s test_detail_view_with_a_past_poll (polls.tests.PollIndexDetailTests)
```

And if there are no tests above the threshold you will see the following message (for example if `SLOW_TEST_THRESHOLD_MS` is set to `400`):

```
$ python manage.py test
Creating test database for alias 'default'...
..........
----------------------------------------------------------------------
Ran 10 tests in 0.413s

OK
Destroying test database for alias 'default'...

No tests slower than 400ms
```

Please let me know if you have any questions!

Thank you,
Nick