### PR TITLE
docs: Fix simple typo, miliseconds -> milliseconds

### DIFF
--- a/django_slowtests/testrunner.py
+++ b/django_slowtests/testrunner.py
@@ -247,7 +247,7 @@ class DiscoverSlowestTestsRunner(DiscoverRunner):
             test_results = []
 
             for result in by_time:
-                # Convert test time from seconds to miliseconds for comparison
+                # Convert test time from seconds to milliseconds for comparison
                 result_time_ms = result[1] * 1000
 
                 # If the test was under the threshold


### PR DESCRIPTION
There is a small typo in django_slowtests/testrunner.py.

Should read `milliseconds` rather than `miliseconds`.

